### PR TITLE
FIX: Updated mongodb to 4.0

### DIFF
--- a/install
+++ b/install
@@ -40,9 +40,9 @@ fi
 
 # mongo
 if ! _skip_install mongodb-org-server; then
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" \
-        > /etc/apt/sources.list.d/mongodb-org-3.2.list
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" \
+        > /etc/apt/sources.list.d/mongodb-org-4.0.list
 
     apt-get -y update
     apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Because the script used 3.2, and Superdesk apparently needs 3.4+ now. (Script stopped with: `ERROR:superdesk:Must be connected to MongoDB 3.4+ to use collations.`)

Key ID comes from: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/