### PR TITLE
Update install with new key to mongodb

### DIFF
--- a/install
+++ b/install
@@ -40,10 +40,15 @@ fi
 
 # mongo
 if ! _skip_install mongodb-org-server; then
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" \
-        > /etc/apt/sources.list.d/mongodb-org-3.2.list
-
+    # remove old mongodb-list (if any)
+    rm /etc/apt/sources.list.d/mongodb*.list
+    
+    # add new public key
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E52529D4
+    
+    # Add the new repo
+    bash -c 'echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" > /etc/apt/sources.list.d/mongodb-org-4.0.list'
+    
     apt-get -y update
     apt-get -y install --no-install-recommends \
         mongodb-org-server \


### PR DESCRIPTION
the current install script stops before installing mongodb

The following has been added to the script

# remove old mongodb-list (if any)
    rm /etc/apt/sources.list.d/mongodb*.list
    
    # add new public key
    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E52529D4
    
    # Add the new repo
    bash -c 'echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" > /etc/apt/sources.list.d/mongodb-org-4.0.list'